### PR TITLE
Antispam health check pre persist

### DIFF
--- a/src/EventListener/QuarantineItemAwareListener.php
+++ b/src/EventListener/QuarantineItemAwareListener.php
@@ -26,7 +26,7 @@ final class QuarantineItemAwareListener
         $this->healthChecker = $healthChecker;
     }
 
-    public function postPersist(LifecycleEventArgs $args): void
+    public function prePersist(LifecycleEventArgs $args): void
     {
         $object = $args->getObject();
         if ($object instanceof QuarantineItemAwareInterface) {

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -19,4 +19,4 @@ services:
     MonsieurBiz\SyliusAntiSpamPlugin\EventListener\QuarantineItemAwareListener:
         tags:
             - name: 'doctrine.event_listener'
-              event: 'postPersist'
+              event: 'prePersist'


### PR DESCRIPTION
To save the quarantine item together with the entity.

For the customer, post creation subscriptions flush the object again, so the quarantine item is saved. But with custom entity, with single flush, the quarantine item is never saved