### PR TITLE
Lift quarantine manually from customer grid or automatically when the customer completes an order

### DIFF
--- a/dist/config/routes/monsieurbiz_sylius_anti_spam_plugin.yaml
+++ b/dist/config/routes/monsieurbiz_sylius_anti_spam_plugin.yaml
@@ -1,1 +1,3 @@
-# To define
+monsieurbiz_sylius_anti_spam_admin:
+    resource: "@MonsieurBizSyliusAntiSpamPlugin/Resources/config/routes/admin.yaml"
+    prefix: /%sylius_admin.path_name%

--- a/recipes/dev/config/routes/monsieurbiz_sylius_anti_spam_plugin.yaml
+++ b/recipes/dev/config/routes/monsieurbiz_sylius_anti_spam_plugin.yaml
@@ -1,1 +1,3 @@
-# To define
+monsieurbiz_sylius_anti_spam_admin:
+    resource: "@MonsieurBizSyliusAntiSpamPlugin/Resources/config/routes/admin.yaml"
+    prefix: /%sylius_admin.path_name%

--- a/src/Entity/QuarantineItemInterface.php
+++ b/src/Entity/QuarantineItemInterface.php
@@ -18,6 +18,8 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 
 interface QuarantineItemInterface extends ResourceInterface
 {
+    public const LEVEL_LIFTED = 0;
+
     public const LEVEL_PROVEN = 16;
 
     public const LEVEL_LIKELY = 8;

--- a/src/EventListener/OrderCompleteListener.php
+++ b/src/EventListener/OrderCompleteListener.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Anti Spam plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusAntiSpamPlugin\EventListener;
+
+use MonsieurBiz\SyliusAntiSpamPlugin\Manager\QuarantineManagerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Webmozart\Assert\Assert;
+
+final class OrderCompleteListener
+{
+    private QuarantineManagerInterface $quarantineManager;
+
+    public function __construct(QuarantineManagerInterface $quarantineManager)
+    {
+        $this->quarantineManager = $quarantineManager;
+    }
+
+    public function liftQuarantine(GenericEvent $event): void
+    {
+        $order = $event->getSubject();
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        $this->quarantineManager->liftQuarantineByOrder($order);
+    }
+}

--- a/src/EventListener/QuarantineInitializeUpdateListener.php
+++ b/src/EventListener/QuarantineInitializeUpdateListener.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Anti Spam plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusAntiSpamPlugin\EventListener;
+
+use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class QuarantineInitializeUpdateListener
+{
+    private RequestStack $requestStack;
+
+    private FlashBagInterface $flashBag;
+
+    private UrlGeneratorInterface $urlGenerator;
+
+    public function __construct(
+        RequestStack $requestStack,
+        FlashBagInterface $flashBag,
+        UrlGeneratorInterface $urlGenerator
+    ) {
+        $this->requestStack = $requestStack;
+        $this->flashBag = $flashBag;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function __invoke(ResourceControllerEvent $resourceControllerEvent): void
+    {
+        $this->flashBag->add('error', 'monsieurbiz_anti_spam.resource.update_quarantine_error');
+        $resourceControllerEvent->setResponse(
+            new RedirectResponse($this->getRedirectUrl())
+        );
+    }
+
+    private function getRedirectUrl(): string
+    {
+        $request = $this->requestStack->getMainRequest();
+        $referer = $request ? $request->headers->get('referer') : null;
+
+        return $referer ?? $this->urlGenerator->generate('sylius_admin_customer_index');
+    }
+}

--- a/src/Form/Type/UpdateQuarantineType.php
+++ b/src/Form/Type/UpdateQuarantineType.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Anti Spam plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusAntiSpamPlugin\Form\Type;
+
+use DateTime;
+use MonsieurBiz\SyliusAntiSpamPlugin\Entity\QuarantineItemInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+final class UpdateQuarantineType extends AbstractType
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameters)
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('level', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('liftedAt', DateTimeType::class)
+            ->addEventListener(FormEvents::SUBMIT, function (FormEvent $event): void {
+                /** @var QuarantineItemInterface $quarantineItem */
+                $quarantineItem = $event->getData();
+
+                // Update liftedAt only if the level is lifted
+                if (QuarantineItemInterface::LEVEL_LIFTED !== $quarantineItem->getLevel()) {
+                    return;
+                }
+
+                $archivedAt = null;
+                if (null === $quarantineItem->getLiftedAt()) {
+                    $archivedAt = new DateTime();
+                }
+                $quarantineItem->setLiftedAt($archivedAt);
+
+                $event->setData($quarantineItem);
+            })
+        ;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'monsieurbiz_anti_spam_update_quarantine';
+    }
+}

--- a/src/Manager/QuarantineManager.php
+++ b/src/Manager/QuarantineManager.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Anti Spam plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusAntiSpamPlugin\Manager;
+
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use MonsieurBiz\SyliusAntiSpamPlugin\Entity\QuarantineItemAwareInterface;
+use MonsieurBiz\SyliusAntiSpamPlugin\Entity\QuarantineItemInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+
+final class QuarantineManager implements QuarantineManagerInterface
+{
+    private EntityManagerInterface $quarantineItemManager;
+
+    public function __construct(EntityManagerInterface $quarantineItemManager)
+    {
+        $this->quarantineItemManager = $quarantineItemManager;
+    }
+
+    public function liftQuarantineByOrder(OrderInterface $order): void
+    {
+        $customer = $order->getCustomer();
+        if (!$customer instanceof QuarantineItemAwareInterface) {
+            return;
+        }
+
+        $quarantineItem = $customer->getQuarantineItem();
+        if (null === $quarantineItem) {
+            return;
+        }
+
+        $this->liftQuarantine($quarantineItem);
+    }
+
+    private function liftQuarantine(QuarantineItemInterface $quarantineItem): void
+    {
+        if (!$quarantineItem->isQuarantined()) {
+            return;
+        }
+
+        $quarantineItem->setLevel(QuarantineItemInterface::LEVEL_LIFTED);
+        $quarantineItem->setLiftedAt(new DateTime());
+
+        $this->quarantineItemManager->flush();
+    }
+}

--- a/src/Manager/QuarantineManagerInterface.php
+++ b/src/Manager/QuarantineManagerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Anti Spam plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusAntiSpamPlugin\Manager;
+
+use Sylius\Component\Core\Model\OrderInterface;
+
+interface QuarantineManagerInterface
+{
+    public function liftQuarantineByOrder(OrderInterface $order): void;
+}

--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -1,0 +1,13 @@
+monsieurbiz_sylius_anti_spam_admin_update_quarantine:
+    path: antispam/update_quarantine
+    methods: [PUT]
+    defaults:
+        _controller: monsieurbiz_anti_spam.controller.quarantine_item:updateAction
+        _sylius:
+            redirect: referer
+            form:
+                type: MonsieurBiz\SyliusAntiSpamPlugin\Form\Type\UpdateQuarantineType
+            repository:
+                method: find
+                arguments: [$quarantineId]
+    

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -24,3 +24,7 @@ services:
     MonsieurBiz\SyliusAntiSpamPlugin\EventListener\QuarantineInitializeUpdateListener:
         tags:
             - { name: kernel.event_listener, event: monsieurbiz_anti_spam.quarantine_item.initialize_update }
+
+    MonsieurBiz\SyliusAntiSpamPlugin\EventListener\OrderCompleteListener:
+        tags:
+            - { name: kernel.event_listener, event: sylius.order.post_complete, method: liftQuarantine }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -20,3 +20,7 @@ services:
         tags:
             - name: 'doctrine.event_listener'
               event: 'prePersist'
+    
+    MonsieurBiz\SyliusAntiSpamPlugin\EventListener\QuarantineInitializeUpdateListener:
+        tags:
+            - { name: kernel.event_listener, event: monsieurbiz_anti_spam.quarantine_item.initialize_update }

--- a/src/Resources/config/sylius/grid.yaml
+++ b/src/Resources/config/sylius/grid.yaml
@@ -1,4 +1,7 @@
 sylius_grid:
+    templates:
+        action:
+            updateQuarantine: "@MonsieurBizSyliusAntiSpamPlugin/Admin/Grid/Action/update_quarantine.html.twig"
     grids:
         sylius_admin_customer:
             fields:
@@ -8,3 +11,7 @@ sylius_grid:
                     path: quarantineItem
                     options:
                         template: '@MonsieurBizSyliusAntiSpamPlugin/Admin/Grid/Field/quarantine_item.html.twig'
+            actions:
+                subitem:
+                    breaking_quarantine:
+                        type: updateQuarantine

--- a/src/Resources/config/sylius/grid.yaml
+++ b/src/Resources/config/sylius/grid.yaml
@@ -11,7 +11,3 @@ sylius_grid:
                     path: quarantineItem
                     options:
                         template: '@MonsieurBizSyliusAntiSpamPlugin/Admin/Grid/Field/quarantine_item.html.twig'
-            actions:
-                subitem:
-                    breaking_quarantine:
-                        type: updateQuarantine

--- a/src/Resources/translations/flashes.en.yaml
+++ b/src/Resources/translations/flashes.en.yaml
@@ -1,0 +1,3 @@
+monsieurbiz_anti_spam:
+    resource:
+        update_quarantine_error: 'Something went wrong, please try again.'

--- a/src/Resources/translations/flashes.fr.yaml
+++ b/src/Resources/translations/flashes.fr.yaml
@@ -1,0 +1,3 @@
+monsieurbiz_anti_spam:
+    resource:
+        update_quarantine_error: 'Une erreur s''est produite, merci de réessayer.'

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -8,6 +8,7 @@ monsieurbiz_anti_spam:
         likely: Likely
         suspected: Suspected
         the_reasons: "The reasons:"
+        lift_quarantine: 'Lift the quarantine'
     error:
         missing_captcha_reponse: 'Missing captcha response.'
         invalid_captcha_score: 'Invalid captcha score.'

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -8,6 +8,7 @@ monsieurbiz_anti_spam:
         likely: Probable
         suspected: Suspecté
         the_reasons: "Les raisons :"
+        lift_quarantine: 'Lever la quarantaine'
     error:
         missing_captcha_reponse: 'Réponse du captcha manquante.'
         invalid_captcha_score: 'Score du captcha insuffisant.'

--- a/src/Resources/views/Admin/Grid/Action/_update_quarantine_button.html.twig
+++ b/src/Resources/views/Admin/Grid/Action/_update_quarantine_button.html.twig
@@ -1,0 +1,19 @@
+{% if data.isQuarantined() %}
+    {% set path = path(options.link.route|default('monsieurbiz_sylius_anti_spam_admin_update_quarantine'), {'quarantineId': data.id}) %}
+
+    <form action="{{ path }}" method="POST" name="monsieurbiz_anti_spam_update_quarantine" style="{{ options.form_style|default('') }}">
+        <input type="hidden" name="_method" value="PUT">
+        <input type="hidden" name="monsieurbiz_anti_spam_update_quarantine[_token]" value="{{ csrf_token('monsieurbiz_anti_spam_update_quarantine') }}" />
+        <input type="hidden" name="monsieurbiz_anti_spam_update_quarantine[level]" value="{{ options.level|default(constant('MonsieurBiz\\SyliusAntiSpamPlugin\\Entity\\QuarantineItemInterface::LEVEL_LIFTED')) }}" />
+
+        <button
+            class="ui{% if not options.without_label|default(false) %} labeled{% endif%} icon button {{ options.size|default('') }}"
+            type="submit"
+            data-requires-confirmation
+            {% if options.without_label|default(false) %}data-tooltip="{{ action.label|default('monsieurbiz_anti_spam.ui.lift_quarantine')|trans }}"{% endif %}
+        >
+            <i class="{{ action.icon|default('lock open') }} icon"></i>
+            {% if not options.without_label|default(false) %}{{ action.label|default('monsieurbiz_anti_spam.ui.lift_quarantine')|trans }}{% endif %}
+        </button>
+    </form>
+{% endif %}

--- a/src/Resources/views/Admin/Grid/Action/update_quarantine.html.twig
+++ b/src/Resources/views/Admin/Grid/Action/update_quarantine.html.twig
@@ -1,14 +1,3 @@
 {% if data.quarantineItem and data.quarantineItem.isQuarantined() %}
-    {% set path = path(options.link.route|default('monsieurbiz_sylius_anti_spam_admin_update_quarantine'), {'quarantineId': data.quarantineItem.id}) %}
-
-    <form action="{{ path }}" method="POST" name="monsieurbiz_anti_spam_update_quarantine">
-        <input type="hidden" name="_method" value="PUT">
-        <input type="hidden" name="monsieurbiz_anti_spam_update_quarantine[_token]" value="{{ csrf_token('monsieurbiz_anti_spam_update_quarantine') }}" />
-        <input type="hidden" name="monsieurbiz_anti_spam_update_quarantine[level]" value="{{ options.level|default(constant('MonsieurBiz\\SyliusAntiSpamPlugin\\Entity\\QuarantineItemInterface::LEVEL_LIFTED')) }}" />
-
-        <button class="ui labeled icon button" type="submit" data-requires-confirmation>
-            <i class="{{ action.icon|default('lock open') }} icon"></i>
-            {{ action.label|default('monsieurbiz_anti_spam.ui.lift_quarantine')|trans }}
-        </button>
-    </form>
+    {% include '@MonsieurBizSyliusAntiSpamPlugin/Admin/Grid/Action/_update_quarantine_button.html.twig' with { 'data': data.quarantineItem } %}
 {% endif %}

--- a/src/Resources/views/Admin/Grid/Action/update_quarantine.html.twig
+++ b/src/Resources/views/Admin/Grid/Action/update_quarantine.html.twig
@@ -1,0 +1,14 @@
+{% if data.quarantineItem and data.quarantineItem.isQuarantined() %}
+    {% set path = path(options.link.route|default('monsieurbiz_sylius_anti_spam_admin_update_quarantine'), {'quarantineId': data.quarantineItem.id}) %}
+
+    <form action="{{ path }}" method="POST" name="monsieurbiz_anti_spam_update_quarantine">
+        <input type="hidden" name="_method" value="PUT">
+        <input type="hidden" name="monsieurbiz_anti_spam_update_quarantine[_token]" value="{{ csrf_token('monsieurbiz_anti_spam_update_quarantine') }}" />
+        <input type="hidden" name="monsieurbiz_anti_spam_update_quarantine[level]" value="{{ options.level|default(constant('MonsieurBiz\\SyliusAntiSpamPlugin\\Entity\\QuarantineItemInterface::LEVEL_LIFTED')) }}" />
+
+        <button class="ui labeled icon button" type="submit" data-requires-confirmation>
+            <i class="{{ action.icon|default('lock open') }} icon"></i>
+            {{ action.label|default('monsieurbiz_anti_spam.ui.lift_quarantine')|trans }}
+        </button>
+    </form>
+{% endif %}

--- a/src/Resources/views/Admin/Grid/Field/quarantine_item.html.twig
+++ b/src/Resources/views/Admin/Grid/Field/quarantine_item.html.twig
@@ -27,6 +27,7 @@
         {{ "monsieurbiz_anti_spam.ui.suspected"|trans }}
     </span>
     {% endif %}
+    {% include '@MonsieurBizSyliusAntiSpamPlugin/Admin/Grid/Action/_update_quarantine_button.html.twig' with { 'options': {'size': 'small', 'form_style': 'display: inline-block', 'without_label': true} } %}
 {% else %}
     <span class="ui green label">
         <i class="check circle outline icon"></i>


### PR DESCRIPTION
Customer grid with "lift" button (updated with last commit):
![image](https://user-images.githubusercontent.com/465524/179943190-a10f9700-7f7d-4919-865d-84cca1d70c63.png)

Example of a manually lifted quarantine:
![antispam-manual-lift](https://user-images.githubusercontent.com/465524/179932489-ace86928-17b3-4063-972a-15440924e957.gif)

Example of an automatically lifted quarantine:
![antispam-auto-lift](https://user-images.githubusercontent.com/465524/179932594-17b03f2a-dce5-400a-ac05-49de4555fa5c.gif)
