### PR TITLE
Allow you to disable recaptcha

### DIFF
--- a/src/Form/Extension/ContactFormExtension.php
+++ b/src/Form/Extension/ContactFormExtension.php
@@ -22,17 +22,28 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 final class ContactFormExtension extends AbstractTypeExtension
 {
+    private bool $karserRecaptcha3Enabled;
+
+    public function __construct(bool $karserRecaptcha3Enabled)
+    {
+        $this->karserRecaptcha3Enabled = $karserRecaptcha3Enabled;
+    }
+
     /**
      * @inheritDoc
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $constraints = [
+            new Recaptcha3Constraint(),
+        ];
+        if ($this->karserRecaptcha3Enabled) {
+            $constraints[] = new Assert\NotBlank();
+        }
+
         $builder->add('captcha', Recaptcha3Type::class, [
             'mapped' => false,
-            'constraints' => [
-                new Recaptcha3Constraint(),
-                new Assert\NotBlank(),
-            ],
+            'constraints' => $constraints,
             'action_name' => 'contact',
         ]);
     }

--- a/src/Form/Extension/CustomerRegistrationFormExtension.php
+++ b/src/Form/Extension/CustomerRegistrationFormExtension.php
@@ -22,17 +22,28 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 final class CustomerRegistrationFormExtension extends AbstractTypeExtension
 {
+    private bool $karserRecaptcha3Enabled;
+
+    public function __construct(bool $karserRecaptcha3Enabled)
+    {
+        $this->karserRecaptcha3Enabled = $karserRecaptcha3Enabled;
+    }
+
     /**
      * @inheritDoc
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $constraints = [
+            new Recaptcha3Constraint(['groups' => 'sylius_user_registration']),
+        ];
+        if ($this->karserRecaptcha3Enabled) {
+            $constraints[] = new Assert\NotBlank(['groups' => 'sylius_user_registration']);
+        }
+
         $builder->add('captcha', Recaptcha3Type::class, [
             'mapped' => false,
-            'constraints' => [
-                new Recaptcha3Constraint(['groups' => 'sylius_user_registration']),
-                new Assert\NotBlank(['groups' => 'sylius_user_registration']),
-            ],
+            'constraints' => $constraints,
             'action_name' => 'register',
         ]);
     }

--- a/src/Resources/views/Shop/form_captcha.html.twig
+++ b/src/Resources/views/Shop/form_captcha.html.twig
@@ -3,6 +3,8 @@
 {% if errors is not empty %}
     {{ errors|raw }}<br />
 {% endif %}
-<div class="ui info message">
-  {{ 'monsieurbiz_anti_spam.form_captcha.message'|trans({'%privacy_link%': 'https://policies.google.com/privacy', '%terms_link%': 'https://policies.google.com/terms'})|raw }}
-</div>
+{% if form.captcha.vars.enabled -%}
+    <div class="ui info message">
+      {{ 'monsieurbiz_anti_spam.form_captcha.message'|trans({'%privacy_link%': 'https://policies.google.com/privacy', '%terms_link%': 'https://policies.google.com/terms'})|raw }}
+    </div>
+{%- endif %}


### PR DESCRIPTION
FYI, CI is fixed in #39

By default, recaptcha is enabled:

![image](https://github.com/monsieurbiz/SyliusAntiSpamPlugin/assets/465524/52292b71-1a43-4150-9ca3-f8e0e9fc2f2e)

But you can choose to disable it in the `config/packages/karser_recaptcha3.yaml`:

```diff
karser_recaptcha3:
    site_key: '%env(RECAPTCHA3_KEY)%'
    secret_key: '%env(RECAPTCHA3_SECRET)%'
    score_threshold: 0.5
+    enabled:false
-    enabled: true
```

![image](https://github.com/monsieurbiz/SyliusAntiSpamPlugin/assets/465524/43652c30-5cf2-4906-a829-aa586d4e3d74)
