### PR TITLE
Avoid error Tagged grid filters needs to have "type" attributes

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -57,6 +57,7 @@ services:
             $captchaMinimumScore: '%karser_recaptcha3.score_threshold%'
 
     MonsieurBiz\SyliusAntiSpamPlugin\Grid\Filter\QuarantineFilter:
+        autoconfigure: false
         tags:
             -   name: sylius.grid_filter
                 type: quarantine


### PR DESCRIPTION
## Correct issue with Sylius Grid 1.13

```
!!    Tagged grid filters needs to have "type" attributes or implements "Sylius\C
!!    omponent\Grid\Filtering\TypeAwareFilterInterface".
```

![image](https://github.com/user-attachments/assets/e238a4b4-0d27-4827-a06d-5cf46a562487)

## Filter works !

![image](https://github.com/user-attachments/assets/06918dc0-55e6-4104-895e-73bfa81ddc4b)
