### PR TITLE
Recaptcha: add translatable validation messages and avoid double empty error

### DIFF
--- a/src/Form/Extension/ContactFormExtension.php
+++ b/src/Form/Extension/ContactFormExtension.php
@@ -18,17 +18,9 @@ use Karser\Recaptcha3Bundle\Validator\Constraints\Recaptcha3 as Recaptcha3Constr
 use Sylius\Bundle\CoreBundle\Form\Type\ContactType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 
 final class ContactFormExtension extends AbstractTypeExtension
 {
-    private bool $karserRecaptcha3Enabled;
-
-    public function __construct(bool $karserRecaptcha3Enabled)
-    {
-        $this->karserRecaptcha3Enabled = $karserRecaptcha3Enabled;
-    }
-
     /**
      * @inheritDoc
      */
@@ -40,9 +32,6 @@ final class ContactFormExtension extends AbstractTypeExtension
                 'messageMissingValue' => 'monsieurbiz_anti_spam_plugin.recaptcha3.empty',
             ]),
         ];
-        if ($this->karserRecaptcha3Enabled) {
-            $constraints[] = new Assert\NotBlank();
-        }
 
         $builder->add('captcha', Recaptcha3Type::class, [
             'mapped' => false,

--- a/src/Form/Extension/ContactFormExtension.php
+++ b/src/Form/Extension/ContactFormExtension.php
@@ -35,7 +35,10 @@ final class ContactFormExtension extends AbstractTypeExtension
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $constraints = [
-            new Recaptcha3Constraint(),
+            new Recaptcha3Constraint([
+                'message' => 'monsieurbiz_anti_spam_plugin.recaptcha3.invalid',
+                'messageMissingValue' => 'monsieurbiz_anti_spam_plugin.recaptcha3.empty',
+            ]),
         ];
         if ($this->karserRecaptcha3Enabled) {
             $constraints[] = new Assert\NotBlank();

--- a/src/Form/Extension/CustomerRegistrationFormExtension.php
+++ b/src/Form/Extension/CustomerRegistrationFormExtension.php
@@ -35,7 +35,11 @@ final class CustomerRegistrationFormExtension extends AbstractTypeExtension
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $constraints = [
-            new Recaptcha3Constraint(['groups' => 'sylius_user_registration']),
+            new Recaptcha3Constraint([
+                'groups' => 'sylius_user_registration',
+                'message' => 'monsieurbiz_anti_spam_plugin.recaptcha3.invalid',
+                'messageMissingValue' => 'monsieurbiz_anti_spam_plugin.recaptcha3.empty',
+            ]),
         ];
         if ($this->karserRecaptcha3Enabled) {
             $constraints[] = new Assert\NotBlank(['groups' => 'sylius_user_registration']);

--- a/src/Form/Extension/CustomerRegistrationFormExtension.php
+++ b/src/Form/Extension/CustomerRegistrationFormExtension.php
@@ -18,17 +18,9 @@ use Karser\Recaptcha3Bundle\Validator\Constraints\Recaptcha3 as Recaptcha3Constr
 use Sylius\Bundle\CoreBundle\Form\Type\Customer\CustomerRegistrationType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 
 final class CustomerRegistrationFormExtension extends AbstractTypeExtension
 {
-    private bool $karserRecaptcha3Enabled;
-
-    public function __construct(bool $karserRecaptcha3Enabled)
-    {
-        $this->karserRecaptcha3Enabled = $karserRecaptcha3Enabled;
-    }
-
     /**
      * @inheritDoc
      */
@@ -41,9 +33,6 @@ final class CustomerRegistrationFormExtension extends AbstractTypeExtension
                 'messageMissingValue' => 'monsieurbiz_anti_spam_plugin.recaptcha3.empty',
             ]),
         ];
-        if ($this->karserRecaptcha3Enabled) {
-            $constraints[] = new Assert\NotBlank(['groups' => 'sylius_user_registration']);
-        }
 
         $builder->add('captcha', Recaptcha3Type::class, [
             'mapped' => false,

--- a/src/Resources/translations/validators.en.yaml
+++ b/src/Resources/translations/validators.en.yaml
@@ -1,0 +1,4 @@
+monsieurbiz_anti_spam_plugin:
+    recaptcha3:
+        invalid: 'Your computer or network may be sending automated queries'
+        empty: 'The captcha value is missing'

--- a/src/Resources/translations/validators.fr.yaml
+++ b/src/Resources/translations/validators.fr.yaml
@@ -1,0 +1,4 @@
+monsieurbiz_anti_spam_plugin:
+    recaptcha3:
+        invalid: 'Votre ordinateur ou votre réseau envoie peut-être des requêtes automatisées'
+        empty: 'La valeur du captcha est manquante'


### PR DESCRIPTION
**Empty error**

![image](https://github.com/user-attachments/assets/ca2b5eb6-f108-4b4e-8cc3-bff13f730252)

**Invalid error**

![image](https://github.com/user-attachments/assets/22306527-ec59-4ffb-89a0-d54103223a07)

**If disable karser_recaptcha3 from config file, no empty message**

![image](https://github.com/user-attachments/assets/c75480be-161e-4eee-8260-0d319f3dd83f)
![image](https://github.com/user-attachments/assets/38ece350-187f-460d-95f5-a50ebb19ba5e)
